### PR TITLE
Duet3 home macros got swapped around

### DIFF
--- a/software/duet3_files_beta/duet3_config_files/homeall.g
+++ b/software/duet3_files_beta/duet3_config_files/homeall.g
@@ -1,8 +1,11 @@
-; Home U Axis
+; Home y, x, z, and Toolchanger Lock axes
 
-G91                     ; Set relative mode
-;G1 U-360 F9000 H1       ; Big negative move to search for home endstop
-G1 U-360 F900 H1       ; Big negative move to search for home endstop
-G1 U6 F600              ; Back off the endstop
-G1 U-10 F600 H1         ; Find endstop again slowly
-G90                     ; Set absolute mode
+G91 G1 Z5 F800 H2           ; Lift z so we don't crash
+M98 P"homey.g"
+M98 P"homex.g"
+
+;M98 P"homez.g"
+
+M98 P"homeu.g"
+
+M98 P"homez.g"

--- a/software/duet3_files_beta/duet3_config_files/homeall.g
+++ b/software/duet3_files_beta/duet3_config_files/homeall.g
@@ -1,11 +1,7 @@
 ; Home y, x, z, and Toolchanger Lock axes
 
-G91 G1 Z5 F800 H2           ; Lift z so we don't crash
+G91 G1 Z5 F800 S2           ; Lift z so we don't crash
 M98 P"homey.g"
 M98 P"homex.g"
-
-;M98 P"homez.g"
-
 M98 P"homeu.g"
-
 M98 P"homez.g"

--- a/software/duet3_files_beta/duet3_config_files/homeu.g
+++ b/software/duet3_files_beta/duet3_config_files/homeu.g
@@ -1,8 +1,7 @@
 ; Home U Axis
 
 G91                     ; Set relative mode
-;G1 U-360 F9000 H1		; Big negative move to search for home endstop
-G1 U-360 F900 H1		; Big negative move to search for home endstop
+G1 U-360 F9000 S1       ; Big negative move to search for home endstop
 G1 U6 F600              ; Back off the endstop
-G1 U-10 F600 H1         ; Find endstop again slowly
+G1 U-10 F600 S1         ; Find endstop again slowly
 G90                     ; Set absolute mode

--- a/software/duet3_files_beta/duet3_config_files/homeu.g
+++ b/software/duet3_files_beta/duet3_config_files/homeu.g
@@ -1,9 +1,8 @@
-	; Home X Axis
+; Home U Axis
 
-	G91                     ; Set relative mode
-	;G1 X-999 F6000 H1       ; Big negative move to search for endstop
-	G1 X-999 F3000 H1       ; Big negative move to search for endstop
-	G1 X4 F600              ; Back off the endstop
-	G1 X-10 F600 H1         ; Find endstop again slowly
-	G90                     ; Set absolute mode
-	G1 X0 F6000
+G91                     ; Set relative mode
+;G1 U-360 F9000 H1		; Big negative move to search for home endstop
+G1 U-360 F900 H1		; Big negative move to search for home endstop
+G1 U6 F600              ; Back off the endstop
+G1 U-10 F600 H1         ; Find endstop again slowly
+G90                     ; Set absolute mode

--- a/software/duet3_files_beta/duet3_config_files/homex.g
+++ b/software/duet3_files_beta/duet3_config_files/homex.g
@@ -1,9 +1,7 @@
-	; Home X Axis
+; Home X Axis
 
-	G91                     ; Set relative mode
-	;G1 X-999 F6000 H1       ; Big negative move to search for endstop
-	G1 X-999 F3000 H1       ; Big negative move to search for endstop
-	G1 X4 F600              ; Back off the endstop
-	G1 X-10 F600 H1         ; Find endstop again slowly
-	G90                     ; Set absolute mode
-	G1 X0 F6000
+G91                     ; Set relative mode
+G1 X-330 F6000 S1       ; Big negative move to search for endstop
+G1 X4 F600              ; Back off the endstop
+G1 X-10 F600 S1         ; Find endstop again slowly
+G90                     ; Set absolute mode

--- a/software/duet3_files_beta/duet3_config_files/homex.g
+++ b/software/duet3_files_beta/duet3_config_files/homex.g
@@ -1,9 +1,9 @@
-; Home Y Axis
+	; Home X Axis
 
-G91                     ; Set relative mode
-;G1 Y-999 F6000 H1       ; Big negative move to search for endstop
-G1 Y-999 F3000 H1       ; Big negative move to search for endstop
-G1 Y4 F600              ; Back off the endstop
-G1 Y-10 F600 H1         ; Find endstop again slowly
-G90                     ; Set absolute mode
-G1 Y0 F6000
+	G91                     ; Set relative mode
+	;G1 X-999 F6000 H1       ; Big negative move to search for endstop
+	G1 X-999 F3000 H1       ; Big negative move to search for endstop
+	G1 X4 F600              ; Back off the endstop
+	G1 X-10 F600 H1         ; Find endstop again slowly
+	G90                     ; Set absolute mode
+	G1 X0 F6000

--- a/software/duet3_files_beta/duet3_config_files/homey.g
+++ b/software/duet3_files_beta/duet3_config_files/homey.g
@@ -1,9 +1,9 @@
-	; Home Z Axis
-	M561 ; Disable any Mesh Bed Compensation
-	G90 G1 X150 Y150 F10000 ; Move to the center of the bed
-	M558 F500 ; Set the probing speed
-	G30
-	M558 F50 ; Set a slower probing speed
-	G30
-	G32                         ; Run 3-point bed calibration defined in bed.g
-	G29 S1   ; Enable Mesh Bed Compensation
+; Home Y Axis
+
+G91                     ; Set relative mode
+;G1 Y-999 F6000 H1		; Big negative move to search for endstop
+G1 Y-999 F3500 H1		; Big negative move to search for endstop
+G1 Y4 F600				; Back off the endstop
+G1 Y-10 F600 H1         ; Find endstop again slowly
+G90                     ; Set absolute mode
+G1 Y0 F6000

--- a/software/duet3_files_beta/duet3_config_files/homey.g
+++ b/software/duet3_files_beta/duet3_config_files/homey.g
@@ -1,9 +1,7 @@
 ; Home Y Axis
 
 G91                     ; Set relative mode
-;G1 Y-999 F6000 H1		; Big negative move to search for endstop
-G1 Y-999 F3500 H1		; Big negative move to search for endstop
-G1 Y4 F600				; Back off the endstop
-G1 Y-10 F600 H1         ; Find endstop again slowly
+G1 Y-386 F6000 S1       ; Big negative move to search for endstop
+G1 Y4 F600              ; Back off the endstop
+G1 Y-10 F600 S1         ; Find endstop again slowly
 G90                     ; Set absolute mode
-G1 Y0 F6000

--- a/software/duet3_files_beta/duet3_config_files/homez.g
+++ b/software/duet3_files_beta/duet3_config_files/homez.g
@@ -1,11 +1,9 @@
-	; Home Z Axis
-	M561 ; Disable any Mesh Bed Compensation
-	G90 G1 X150 Y150 F10000 ; Move to the center of the bed
-	M558 F500 ; Set the probing speed
-	G30
-	M558 F50 ; Set a slower probing speed
-	G30
-	G32      ; Run 3-point bed calibration defined in bed.g
-	G29 S1   ; Enable Mesh Bed Compensation
-	G1 Z5
-	G1 X50 Y50 F10000
+; Home Z Axis
+;M561 ; Disable any Mesh Bed Compensation
+G90 G1 X150 Y150 F10000 ; Move to the center of the bed
+M558 F500 ; Set the probing speed
+G30
+M558 F50 ; Set a slower probing speed
+G30
+G32                         ; Run 3-point bed calibration defined in bed.g
+;G29 S1   ; Enable Mesh Bed Compensation

--- a/software/duet3_files_beta/duet3_config_files/homez.g
+++ b/software/duet3_files_beta/duet3_config_files/homez.g
@@ -1,7 +1,11 @@
-; Pause macro file
-M83					; relative extruder moves
-G1 E-3 F2500		; retract 4mm
-G91					; relative moves
-G1 Z30 F5000			; raise nozzle 2mm
-G90					; absolute moves
-G1 X305 Y85 F5000		; move head out of the way of the print
+	; Home Z Axis
+	M561 ; Disable any Mesh Bed Compensation
+	G90 G1 X150 Y150 F10000 ; Move to the center of the bed
+	M558 F500 ; Set the probing speed
+	G30
+	M558 F50 ; Set a slower probing speed
+	G30
+	G32      ; Run 3-point bed calibration defined in bed.g
+	G29 S1   ; Enable Mesh Bed Compensation
+	G1 Z5
+	G1 X50 Y50 F10000


### PR DESCRIPTION
For some reason, all of the duet3 homing macros got renamed - home x actually homed y, etc. Since there isn't any difference between the old (duet2) homing macros and the new ones, I just copied them over.