### PR TITLE
Dev/jubilee 2.2.0 Added automatic homing protection to every axis

### DIFF
--- a/software/duet_config_files/duet2/rrf3/sys/homeall.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeall.g
@@ -1,7 +1,7 @@
 ; Home y, x, z, and Toolchanger Lock axes
 
 G91 G1 Z5 F800 S2           ; Lift z so we don't crash
+M98 P"homeu.g"              ; Home u first In case a tool is currently active
 M98 P"homey.g"
 M98 P"homex.g"
-M98 P"homeu.g"
 M98 P"homez.g"

--- a/software/duet_config_files/duet2/rrf3/sys/homeall.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeall.g
@@ -1,6 +1,7 @@
 ; Home y, x, z, and Toolchanger Lock axes
 
 G91 G1 Z5 F800 H2           ; Lift z so we don't crash
+
 M98 P"homeu.g"              ; X and Z require U to be homed first in case a tool is currently active
 M98 P"homey.g"
 M98 P"homex.g"

--- a/software/duet_config_files/duet2/rrf3/sys/homeall.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeall.g
@@ -1,7 +1,7 @@
 ; Home y, x, z, and Toolchanger Lock axes
 
 G91 G1 Z5 F800 S2           ; Lift z so we don't crash
-M98 P"homeu.g"              ; Home u first In case a tool is currently active
+M98 P"homeu.g"              ; X and Z require U to be homed first in case a tool is currently active
 M98 P"homey.g"
 M98 P"homex.g"
 M98 P"homez.g"

--- a/software/duet_config_files/duet2/rrf3/sys/homeall.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeall.g
@@ -1,6 +1,6 @@
 ; Home y, x, z, and Toolchanger Lock axes
 
-G91 G1 Z5 F800 S2           ; Lift z so we don't crash
+G91 G1 Z5 F800 H2           ; Lift z so we don't crash
 M98 P"homeu.g"              ; X and Z require U to be homed first in case a tool is currently active
 M98 P"homey.g"
 M98 P"homex.g"

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -7,10 +7,10 @@
 G90                     ; Set absolute mode
 G92 U0                  ; Define current position as 0 to enable move without homing
 G1 U2 H2 F5000          ; Move the axis 2deg to back it off of the unlocked switch
-G1 U160 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop
+G1 U120 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop
 M400                    ; Make sure moves are complete
 
-if abs(move.axes[3].userPosition - 160) > 1
+if abs(move.axes[3].userPosition - 120) > 1
     M84 U
     M291 R"Intervention Required" P"Please remove the tool, return it to its post, and restore the twist lock to its unlocked (horizontal) position. Press OK to continue..." S3
 T-1 P0                  ; Set current tool to none

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -4,6 +4,7 @@
 ; 1. No tool attached (U=0), usually the result of the tool being properly parked.
 ; 2. Tool attached (U=?), usually the result of the machine being powered powered off with a tool still active.
 
+G90                     ; Set absolute mode
 G92 U0                  ; Define current position as 0 to enable move without homing
 G1 U2 H2 F5000          ; Move the axis 2deg to back it off of the unlocked switch
 G1 U170 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -12,7 +12,7 @@ M400                    ; Make sure moves are complete
 
 if abs(move.axes[3].userPosition - 170) > 1
     M84 U
-    M291 R"Intervention Required" P"Please remove the tool, return it to its post, and restore the twist lock to its unlocked (horizontal) position. Press OK to continue..." S2
+    M291 R"Intervention Required" P"Please remove the tool, return it to its post, and restore the twist lock to its unlocked (horizontal) position. Press OK to continue..." S3
 T-1 P0                  ; Set current tool to none
 
 G91                     ; Set relative mode

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -13,6 +13,7 @@ M400                    ; Make sure moves are complete
 if abs(move.axes[3].userPosition - 170) > 1
     M84 U
     M291 R"Intervention Required" P"A tool has been detected! Please remove and return to post. Press OK to continue..." S2
+T-1 P0                  ; Set current tool to none
 
 G91                     ; Set relative mode
 G1 U-360 F9000 H1       ; Big negative move to search for home endstop

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -1,8 +1,20 @@
 ; Home U Axis
 
+; Assumes the tool changer is in 1 of 2 possible states.
+; 1. No tool attached (U=0), usually the result of the tool being properly parked.
+; 2. Tool attached (U=?), usually the result of the machine being powered powered off with a tool still active.
+
+G92 U0                  ; Define current position as 0 to enable move without homing
+G1 U2 H2 F5000          ; Move the axis 2deg to back it off of the unlocked switch
+G1 U170 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop
+M400                    ; Make sure moves are complete
+
+if abs(move.axes[3].userPosition - 170) > 1
+    M84 U
+    M291 R"Intervention Required" P"A tool has been detected! Please remove and return to post. Press OK to continue..." S2
+
 G91                     ; Set relative mode
 G1 U-360 F9000 H1       ; Big negative move to search for home endstop
 G1 U6 F600              ; Back off the endstop
 G1 U-15 F600 H1         ; Find endstop again slowly
 G90                     ; Set absolute mode
-

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -7,10 +7,10 @@
 G90                     ; Set absolute mode
 G92 U0                  ; Define current position as 0 to enable move without homing
 G1 U2 H2 F5000          ; Move the axis 2deg to back it off of the unlocked switch
-G1 U170 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop
+G1 U160 H1 F5000        ; Move the axis to 170deg, or until it hits an endstop
 M400                    ; Make sure moves are complete
 
-if abs(move.axes[3].userPosition - 170) > 1
+if abs(move.axes[3].userPosition - 160) > 1
     M84 U
     M291 R"Intervention Required" P"Please remove the tool, return it to its post, and restore the twist lock to its unlocked (horizontal) position. Press OK to continue..." S3
 T-1 P0                  ; Set current tool to none

--- a/software/duet_config_files/duet2/rrf3/sys/homeu.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homeu.g
@@ -12,7 +12,7 @@ M400                    ; Make sure moves are complete
 
 if abs(move.axes[3].userPosition - 170) > 1
     M84 U
-    M291 R"Intervention Required" P"A tool has been detected! Please remove and return to post. Press OK to continue..." S2
+    M291 R"Intervention Required" P"Please remove the tool, return it to its post, and restore the twist lock to its unlocked (horizontal) position. Press OK to continue..." S2
 T-1 P0                  ; Set current tool to none
 
 G91                     ; Set relative mode

--- a/software/duet_config_files/duet2/rrf3/sys/homex.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homex.g
@@ -1,5 +1,9 @@
 ; Home X Axis
 
+if !move.axes[3].homed
+  M291 R"Cannot Home X" P"U axis must be homed before X to prevent damage to tool. Press OK to home U or Cancel to abort" S3
+  G28 U
+
 G91                     ; Set relative mode
 G1 X-330 F6000 H1       ; Big negative move to search for endstop
 G1 X4 F600              ; Back off the endstop

--- a/software/duet_config_files/duet2/rrf3/sys/homex.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homex.g
@@ -4,9 +4,14 @@ if !move.axes[3].homed
   M291 R"Cannot Home X" P"U axis must be homed before X to prevent damage to tool. Press OK to home U or Cancel to abort" S3
   G28 U
 
+if state.currentTool != -1
+  M84 U
+  M291 R"Cannot Home X" P"Tool must be deselected before homing. U has been unlocked, please manually dock tool and press OK to continue or Cancel to abort" S3
+  G28 U
+
 G91                     ; Set relative mode
 G1 X-330 F6000 H1       ; Big negative move to search for endstop
 G1 X4 F600              ; Back off the endstop
 G1 X-10 F600 H1         ; Find endstop again slowly
 G1 X2 F600              ; Relieve strain from endstop
-G90                     ; Set absolute mode
+G90    

--- a/software/duet_config_files/duet2/rrf3/sys/homex.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homex.g
@@ -1,8 +1,24 @@
 ; Home X Axis
 
+; In case homex.g is called in isolation, ensure 
+; (1) U axis is homed (which performs tool detection and sets machine tool state to a known state) and 
+; (2) Y axis is homed (to prevent collisions with the tool posts)
+; (3) Y axis is in a safe position (see 2)
+; (4) No tools are loaded.
+; Ask for user-intervention if either case fails.
+
+G90                     ; Set absolute mode
+
 if !move.axes[3].homed
   M291 R"Cannot Home X" P"U axis must be homed before X to prevent damage to tool. Press OK to home U or Cancel to abort" S3
   G28 U
+
+if !move.axes[1].homed
+  M291 R"Cannot Home X" P"Y axis must be homed before x to prevent damage to tool. Press OK to home Y or Cancel to abort" S3
+  G28 Y
+  
+if move.axes[1].userPosition >= 305
+  G0 Y305 F20000       ; Rapid to safe y position
 
 if state.currentTool != -1
   M84 U
@@ -14,4 +30,4 @@ G1 X-330 F6000 H1       ; Big negative move to search for endstop
 G1 X4 F600              ; Back off the endstop
 G1 X-10 F600 H1         ; Find endstop again slowly
 G1 X2 F600              ; Relieve strain from endstop
-G90    
+G90                     ; Set absolute mode

--- a/software/duet_config_files/duet2/rrf3/sys/homex.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homex.g
@@ -8,4 +8,5 @@ G91                     ; Set relative mode
 G1 X-330 F6000 H1       ; Big negative move to search for endstop
 G1 X4 F600              ; Back off the endstop
 G1 X-10 F600 H1         ; Find endstop again slowly
+G1 X2 F600              ; Relieve strain from endstop
 G90                     ; Set absolute mode

--- a/software/duet_config_files/duet2/rrf3/sys/homey.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homey.g
@@ -1,8 +1,7 @@
 ; Home Y Axis
 
 G91                     ; Set relative mode
-G1 Y-386 F6000 H1       ; Big negative move to search for endstop
+G1 Y-400 F6000 H1       ; Big negative move to search for endstop
 G1 Y4 F600              ; Back off the endstop
 G1 Y-10 F600 H1         ; Find endstop again slowly
-G1 Y2 F600              ; Relieve strain from endstop
 G90                     ; Set absolute mode

--- a/software/duet_config_files/duet2/rrf3/sys/homey.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homey.g
@@ -4,5 +4,5 @@ G91                     ; Set relative mode
 G1 Y-386 F6000 H1       ; Big negative move to search for endstop
 G1 Y4 F600              ; Back off the endstop
 G1 Y-10 F600 H1         ; Find endstop again slowly
-G1 Y2 G600              ; Relieve strain from endstop
+G1 Y2 F600              ; Relieve strain from endstop
 G90                     ; Set absolute mode

--- a/software/duet_config_files/duet2/rrf3/sys/homey.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homey.g
@@ -4,4 +4,5 @@ G91                     ; Set relative mode
 G1 Y-386 F6000 H1       ; Big negative move to search for endstop
 G1 Y4 F600              ; Back off the endstop
 G1 Y-10 F600 H1         ; Find endstop again slowly
+G1 Y2 G600              ; Relieve strain from endstop
 G90                     ; Set absolute mode

--- a/software/duet_config_files/duet2/rrf3/sys/homez.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homez.g
@@ -4,6 +4,11 @@ if !move.axes[3].homed
   M291 R"Cannot Home Z" P"U axis must be homed before Z to prevent damage to tool. Press OK to home U or Cancel to abort" S3
   G28 U
 
+; RRF3 does not permit Z homing without x&y being homed first. Popup window for convenience.
+if !move.axes[0].homed || !move.axes[1].homed
+  M291 R"Cannot Home Z" P"X&Y Axes must be homed before Z for probing. Press OK to home X&Y or Cancel to abort" S3
+  G28 Y X
+
 if state.currentTool != -1
   M84 U
   M291 R"Cannot Home Z" P"Tool must be deselected before homing. U has been unlocked, please manually dock tool and press OK to continue or Cancel to abort" S3

--- a/software/duet_config_files/duet2/rrf3/sys/homez.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homez.g
@@ -1,4 +1,9 @@
 ; Home Z Axis
+
+if !move.axes[3].homed
+  M291 R"Cannot Home Z" P"U axis must be homed before Z to prevent damage to tool. Press OK to home U or Cancel to abort" S3
+  G28 U
+
 M561 ; Disable any Mesh Bed Compensation
 G90 G1 X150 Y150 F10000 ; Move to the center of the bed
 M558 F500 ; Set the probing speed

--- a/software/duet_config_files/duet2/rrf3/sys/homez.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homez.g
@@ -4,6 +4,11 @@ if !move.axes[3].homed
   M291 R"Cannot Home Z" P"U axis must be homed before Z to prevent damage to tool. Press OK to home U or Cancel to abort" S3
   G28 U
 
+if state.currentTool != -1
+  M84 U
+  M291 R"Cannot Home Z" P"Tool must be deselected before homing. U has been unlocked, please manually dock tool and press OK to continue or Cancel to abort" S3
+  G28 U
+
 M561 ; Disable any Mesh Bed Compensation
 G90 G1 X150 Y150 F10000 ; Move to the center of the bed
 M558 F500 ; Set the probing speed


### PR DESCRIPTION
homeu.g detects if a tool is present and requires user to manually remove tool if present.
homex.g requires u to be homed and no active tools
homey.g function as before
homez.g requires u to be homed and no active tools
homeall.g changed homing order to put u before xyz