### PR TITLE
Added jammed endstop detection

### DIFF
--- a/software/duet_config_files/duet2/rrf3/sys/homex.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homex.g
@@ -5,7 +5,8 @@
 ; (2) Y axis is homed (to prevent collisions with the tool posts)
 ; (3) Y axis is in a safe position (see 2)
 ; (4) No tools are loaded.
-; Ask for user-intervention if either case fails.
+; (5) Endstop is not already triggered (in case of damaged endstop)
+; Ask for user-intervention if any case fails.
 
 G90                     ; Set absolute mode
 
@@ -24,6 +25,10 @@ if state.currentTool != -1
   M84 U
   M291 R"Cannot Home X" P"Tool must be deselected before homing. U has been unlocked, please manually dock tool and press OK to continue or Cancel to abort" S3
   G28 U
+  
+if sensors.endstops[0].triggered
+  M291 "Cannot Home X" P"X Endstop is already triggered!" S2
+  abort "X Endstop was triggered before homing."
 
 G91                     ; Set relative mode
 G1 X-330 F6000 H1       ; Big negative move to search for endstop

--- a/software/duet_config_files/duet2/rrf3/sys/homey.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homey.g
@@ -1,5 +1,13 @@
 ; Home Y Axis
 
+; In case homey.g is called in isolation, ensure
+; (1) Endstop is not already triggered (in case of damaged endstop)
+; Ask for user-intervention if any case fails.
+
+if sensors.endstops[1].triggered
+  M291 "Cannot Home Y" P"Y Endstop is already triggered!" S2
+  abort "Y Endstop was triggered before homing."
+
 G91                     ; Set relative mode
 G1 Y-400 F6000 H1       ; Big negative move to search for endstop
 G1 Y4 F600              ; Back off the endstop

--- a/software/duet_config_files/duet2/rrf3/sys/homez.g
+++ b/software/duet_config_files/duet2/rrf3/sys/homez.g
@@ -1,5 +1,12 @@
 ; Home Z Axis
 
+; In case homez.g is called in isolation, ensure 
+; (1) U axis is homed (which performs tool detection and sets machine tool state to a known state) and 
+; (2) X&Y axis is homed (to prevent collisions with the tool posts)
+; (3) No tools are loaded.
+; (4) Endstop is not already triggered (in case of damaged endstop)
+; Ask for user-intervention if any case fails.
+
 if !move.axes[3].homed
   M291 R"Cannot Home Z" P"U axis must be homed before Z to prevent damage to tool. Press OK to home U or Cancel to abort" S3
   G28 U
@@ -13,6 +20,10 @@ if state.currentTool != -1
   M84 U
   M291 R"Cannot Home Z" P"Tool must be deselected before homing. U has been unlocked, please manually dock tool and press OK to continue or Cancel to abort" S3
   G28 U
+
+if sensors.probes[0].value[0] != 0
+  M291 R"Cannot Home Z" P"Z Probe is already triggered!" S2
+  abort "Z Probe was triggered before homing."
 
 M561 ; Disable any Mesh Bed Compensation
 G90 G1 X150 Y150 F10000 ; Move to the center of the bed


### PR DESCRIPTION
Throws error if relevant endstop was already triggered for XYZ homing. Detection not added to U axis because both natural states leave it triggered.