### PR TITLE
fix typo in duet3d-mini command.g file (missing comment)

### DIFF
--- a/software/duet_config_files/duet3_mini_with_3hc/sys/config.g
+++ b/software/duet_config_files/duet3_mini_with_3hc/sys/config.g
@@ -110,7 +110,7 @@ G31 K0 X0 Y0 Z-2        ; Set the limit switch as the "Control Point"
 
 ; Set axis software limits and min/max switch-triggering positions.
 ; Dimensions are adjusted such that (0,0) lies at the lower left corner
-of a centered 300x300mm square in the 305mmx305mm build plate.
+; of a centered 300x300mm square in the 305mmx305mm build plate.
 M208 X-13.75:313.75 Y-44:341 Z0:300
 M208 U0:200            ; Set Elastic Lock (U axis) max rotation angle
 


### PR DESCRIPTION
I think there's a missing semicolon on a comment.